### PR TITLE
Add T36 IT CPE conditions

### DIFF
--- a/Configuration/AlCa/python/autoCondPhase2.py
+++ b/Configuration/AlCa/python/autoCondPhase2.py
@@ -29,7 +29,7 @@ allTags["LA"] = {
     'T25' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T25_v0_mc' ,SiPixelLARecord,connectionString, "", "2021-03-16 20:00:00.000"] ), ),  #uH = 0.053/T (TBPX L2,L3,L4), uH=0.0/T (TBPX L1 TEPX+TFPX)
     'T30' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_IT_v6.4.0_25x100_v1_mc' ,SiPixelLARecord,connectionString, "", "2021-11-22 21:00:00.000"] ), ),  #uH = 0.053/T (TBPX), uH=0.0/T (TEPX+TFPX)
     'T33' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_IT_v7.1.1_25x100_v1_mc' ,SiPixelLARecord,connectionString, "", "2023-05-16 20:00:00.000"] ), ),  #uH = 0.053/T (TBPX L2,L3,L4), uH=0.0/T (TBPX L1 TEPX+TFPX)
-    'T36' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_IT_v7.4.1_25x100_v1_mc' ,SiPixelLARecord,connectionString, "", "2024-??-?? ??:00:00.???"] ), ),  #uH = 0.053/T (TBPX L2,L3,L4), uH=0.0/T (TBPX L1 TEPX+TFPX)
+    'T36' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_IT_v7.4.1_25x100_v1_mc' ,SiPixelLARecord,connectionString, "", "2024-03-04 21:00:00.000"] ), ),  #uH = 0.053/T (TBPX L2,L3,L4), uH=0.0/T (TBPX L1 TEPX+TFPX)
 }
 
 allTags["LAWidth"] = {
@@ -37,7 +37,7 @@ allTags["LAWidth"] = {
     'T25' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T19_mc_forWidthEmpty' ,SiPixelLARecord,connectionString, "forWidth", "2020-02-23 14:00:00.000"] ), ),  # uH=0.0/T (fall-back to offset)
     'T30' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_IT_v6.4.0_25x100_empty_mc' ,SiPixelLARecord,connectionString, "forWidth", "2021-11-29 20:00:00.000"] ), ),  # uH=0.0/T (fall-back to offset)
     'T33' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_IT_v7.1.1_25x100_empty_mc' ,SiPixelLARecord,connectionString, "forWidth", "2023-12-02 15:55:00.000"] ), ),  # uH=0.0/T (fall-back to offset)
-    'T36' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_IT_v7.4.1_25x100_empty_mc' ,SiPixelLARecord,connectionString, "forWidth", "2024-??-?? ??:00:00.???"] ), ),  # uH=0.0/T (fall-back to offset)
+    'T36' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_IT_v7.4.1_25x100_empty_mc' ,SiPixelLARecord,connectionString, "forWidth", "2024-03-04 21:00:00.000"] ), ),  # uH=0.0/T (fall-back to offset)
 }
 
 allTags["LAfromAlignment"] = {
@@ -51,7 +51,7 @@ allTags["SimLA"] = {
     'T21' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T15_v5_mc' ,SiPixelSimLARecord,connectionString, "", "2020-05-05 20:00:00.000"] ), ), #uH = 0.053/T (TBPX), uH=0.0/T (TEPX+TFPX)
     'T25' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T25_v0_mc' ,SiPixelSimLARecord,connectionString, "", "2021-03-16 20:00:00.000"] ), ), #uH = 0.053/T (TBPX L2,L3,L4), uH=0.0/T (TBPX L1 TEPX+TFPX)
     'T30' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_IT_v6.4.0_25x100_v1_mc' ,SiPixelSimLARecord,connectionString, "", "2021-12-03 16:00:00.000"] ), ), #uH = 0.053/T (TBPX), uH=0.0/T (TEPX+TFPX)
-    'T36' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_IT_v7.4.1_25x100_v1_mc' ,SiPixelSimLARecord,connectionString, "", "2024-??-?? ??:00:00.???"] ), ), #uH = 0.053/T (TBPX), uH=0.0/T (TEPX+TFPX)
+    'T36' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_IT_v7.4.1_25x100_v1_mc' ,SiPixelSimLARecord,connectionString, "", "2024-03-04 21:00:00.000"] ), ), #uH = 0.053/T (TBPX  L2,L3,L4), uH=0.0/T (TBPX L1 TEPX+TFPX)
 }
 
 allTags["GenError"] = {
@@ -59,7 +59,7 @@ allTags["GenError"] = {
     'T25' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v7.0.2_25x100_v2_mc' ,SiPixelGenErrorRecord,connectionString, "", "2021-04-17 20:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y), VBias=350V, 3D pixels in TBPX L1
     'T30' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.4.0_25x100_v1_mc',SiPixelGenErrorRecord,connectionString, "", "2021-11-22 21:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
     'T33' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v7.1.1_25x100_v1_mc' ,SiPixelGenErrorRecord,connectionString, "", "2023-05-16 20:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V, 3D pixels in TBPX L1
-    'T36' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v7.4.1_25x100_v1_mc' ,SiPixelGenErrorRecord,connectionString, "", "2024-??-?? ??:00:??"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V, 3D pixels in TBPX L1
+    'T36' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v7.4.1_25x100_v1_mc' ,SiPixelGenErrorRecord,connectionString, "", "2024-03-04 21:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V, 3D pixels in TBPX L1
 }
 
 allTags["Template"] = {
@@ -67,7 +67,7 @@ allTags["Template"] = {
     'T25' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v7.0.2_25x100_v2_mc' ,SiPixelTemplatesRecord,connectionString, "", "2021-04-17 20:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y), VBias=350V, 3D pixels in TBPX L1
     'T30' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.4.0_25x100_v1_mc',SiPixelTemplatesRecord,connectionString, "", "2021-11-22 21:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
     'T33' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v7.1.1_25x100_v1_mc' ,SiPixelTemplatesRecord,connectionString, "", "2023-05-16 20:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V, 3D pixels in TBPX L1
-    'T36' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v7.4.1_25x100_v1_mc' ,SiPixelTemplatesRecord,connectionString, "", "2024-??-?? ??:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V, 3D pixels in TBPX L1
+    'T36' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v7.4.1_25x100_v1_mc' ,SiPixelTemplatesRecord,connectionString, "", "2024-03-04 21:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V, 3D pixels in TBPX L1
 }
 
 allTags["TkAlignment"] = {


### PR DESCRIPTION
#### PR description:

Add T36 IT CPE conditions

```
SiPixelSimLorentzAngle_phase2_IT_v7.4.1_25x100_v1_mc
SiPixelLorentzAngle_phase2_IT_v7.4.1_25x100_v1_mc
SiPixelTemplateDBObject_phase2_IT_v7.4.1_25x100_v1_mc
SiPixelGenErrorDBObject_phase2_IT_v7.4.1_25x100_v1_mc
SiPixelLorentzAngle_phase2_IT_v7.4.1_25x100_empty_mc
```
 
LA PI https://cern.ch/sfb6s
GenErr/Template headers: https://cern.ch/gxdt5
For the empty LA: https://cern.ch/qlk27