### PR TITLE
Test conditions for T36

### DIFF
--- a/Configuration/AlCa/python/autoCondPhase2.py
+++ b/Configuration/AlCa/python/autoCondPhase2.py
@@ -1,5 +1,6 @@
 from Configuration.StandardSequences.CondDBESSource_cff import GlobalTag as essource
 connectionString = essource.connect.value()
+connectionStringDev = "frontier://FrontierPrep/CMS_CONDITIONS"
 
 SiPixelLARecord           =   "SiPixelLorentzAngleRcd"            
 SiPixelSimLARecord        =   "SiPixelLorentzAngleSimRcd"
@@ -29,7 +30,7 @@ allTags["LA"] = {
     'T25' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T25_v0_mc' ,SiPixelLARecord,connectionString, "", "2021-03-16 20:00:00.000"] ), ),  #uH = 0.053/T (TBPX L2,L3,L4), uH=0.0/T (TBPX L1 TEPX+TFPX)
     'T30' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_IT_v6.4.0_25x100_v1_mc' ,SiPixelLARecord,connectionString, "", "2021-11-22 21:00:00.000"] ), ),  #uH = 0.053/T (TBPX), uH=0.0/T (TEPX+TFPX)
     'T33' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_IT_v7.1.1_25x100_v1_mc' ,SiPixelLARecord,connectionString, "", "2023-05-16 20:00:00.000"] ), ),  #uH = 0.053/T (TBPX L2,L3,L4), uH=0.0/T (TBPX L1 TEPX+TFPX)
-   # 'T36' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_IT_v7.4.1_25x100_v1_mc' ,SiPixelLARecord,connectionString, "", "2024-??-?? ??:00:00.000"] ), ),  #uH = 0.053/T (TBPX L2,L3,L4), uH=0.0/T (TBPX L1 TEPX+TFPX)
+    'T36' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_IT_v7.4.1_25x100_v2_mc' ,SiPixelLARecord,connectionStringDev, "", "2024-03-21 12:00:00.000"] ), ),  #uH = 0.053/T (TBPX L2,L3,L4), uH=0.0/T (TBPX L1 TEPX+TFPX)
 }
 
 allTags["LAWidth"] = {
@@ -37,7 +38,7 @@ allTags["LAWidth"] = {
     'T25' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T19_mc_forWidthEmpty' ,SiPixelLARecord,connectionString, "forWidth", "2020-02-23 14:00:00.000"] ), ),  # uH=0.0/T (fall-back to offset)
     'T30' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_IT_v6.4.0_25x100_empty_mc' ,SiPixelLARecord,connectionString, "forWidth", "2021-11-29 20:00:00.000"] ), ),  # uH=0.0/T (fall-back to offset)
     'T33' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_IT_v7.1.1_25x100_empty_mc' ,SiPixelLARecord,connectionString, "forWidth", "2023-12-02 15:55:00.000"] ), ),  # uH=0.0/T (fall-back to offset)
-#    'T36' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_IT_v7.4.1_25x100_empty_mc' ,SiPixelLARecord,connectionString, "forWidth", "2024-??-?? ??:00:00.000"] ), ),  # uH=0.0/T (fall-back to offset)
+    'T36' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_IT_v7.4.1_25x100_empty_mc' ,SiPixelLARecord,connectionStringDev, "forWidth", "2024-03-21 12:00:00.000"] ), ),  # uH=0.0/T (fall-back to offset)
 }
 
 allTags["LAfromAlignment"] = {
@@ -45,14 +46,14 @@ allTags["LAfromAlignment"] = {
     'T25' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_T19_mc_forWidthEmpty' ,SiPixelLARecord,connectionString, "fromAlignment", "2020-02-23 14:00:00.000"] ), ),  # uH=0.0/T (not in use)
     'T30' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_IT_v6.4.0_25x100_empty_mc' ,SiPixelLARecord,connectionString, "fromAlignment", "2021-11-29 20:00:00.000"] ), ),  # uH=0.0/T (fall-back to offset)
     'T33' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_IT_v7.1.1_25x100_empty_mc' ,SiPixelLARecord,connectionString, "fromAlignment", "2023-12-02 15:55:00.000"] ), ),  # uH=0.0/T (fall-back to offset)
- #   'T36' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_IT_v7.4.1_25x100_empty_mc' ,SiPixelLARecord,connectionString, "fromAlignment", "2024-??-?? ??:00:00.000"] ), ),  # uH=0.0/T (fall-back to offset)
+    'T36' : ( ','.join( [ 'SiPixelLorentzAngle_phase2_IT_v7.4.1_25x100_empty_mc' ,SiPixelLARecord,connectionStringDev, "fromAlignment", "2024-03-21 12:00:00.000"] ), ),  # uH=0.0/T (fall-back to offset)
 }
 
 allTags["SimLA"] = {
     'T21' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T15_v5_mc' ,SiPixelSimLARecord,connectionString, "", "2020-05-05 20:00:00.000"] ), ), #uH = 0.053/T (TBPX), uH=0.0/T (TEPX+TFPX)
     'T25' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_T25_v0_mc' ,SiPixelSimLARecord,connectionString, "", "2021-03-16 20:00:00.000"] ), ), #uH = 0.053/T (TBPX L2,L3,L4), uH=0.0/T (TBPX L1 TEPX+TFPX)
     'T30' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_IT_v6.4.0_25x100_v1_mc' ,SiPixelSimLARecord,connectionString, "", "2021-12-03 16:00:00.000"] ), ), #uH = 0.053/T (TBPX), uH=0.0/T (TEPX+TFPX)
-  #  'T36' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_IT_v7.4.1_25x100_v1_mc' ,SiPixelSimLARecord,connectionString, "", "2024-??-?? ??:00:00.000"] ), ), #uH = 0.053/T (TBPX  L2,L3,L4), uH=0.0/T (TBPX L1 TEPX+TFPX)
+    'T36' : ( ','.join( [ 'SiPixelSimLorentzAngle_phase2_IT_v7.4.1_25x100_v2_mc' ,SiPixelSimLARecord,connectionStringDev, "", "2024-03-21 13:30:00.000"] ), ), #uH = 0.053/T (TBPX  L2,L3,L4), uH=0.0/T (TBPX L1 TEPX+TFPX)
 }
 
 allTags["GenError"] = {
@@ -60,7 +61,7 @@ allTags["GenError"] = {
     'T25' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v7.0.2_25x100_v2_mc' ,SiPixelGenErrorRecord,connectionString, "", "2021-04-17 20:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y), VBias=350V, 3D pixels in TBPX L1
     'T30' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.4.0_25x100_v1_mc',SiPixelGenErrorRecord,connectionString, "", "2021-11-22 21:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
     'T33' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v7.1.1_25x100_v1_mc' ,SiPixelGenErrorRecord,connectionString, "", "2023-05-16 20:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V, 3D pixels in TBPX L1
-  #  'T36' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v7.4.1_25x100_v1_mc' ,SiPixelGenErrorRecord,connectionString, "", "2024-??-?? ??:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V, 3D pixels in TBPX L1
+    'T36' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v7.4.1_25x100_v2_mc' ,SiPixelGenErrorRecord,connectionStringDev, "", "2024-03-21 12:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V, 3D pixels in TBPX L1
 }
 
 allTags["Template"] = {
@@ -68,7 +69,7 @@ allTags["Template"] = {
     'T25' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v7.0.2_25x100_v2_mc' ,SiPixelTemplatesRecord,connectionString, "", "2021-04-17 20:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y), VBias=350V, 3D pixels in TBPX L1
     'T30' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.4.0_25x100_v1_mc',SiPixelTemplatesRecord,connectionString, "", "2021-11-22 21:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
     'T33' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v7.1.1_25x100_v1_mc' ,SiPixelTemplatesRecord,connectionString, "", "2023-05-16 20:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V, 3D pixels in TBPX L1
-  #  'T36' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v7.4.1_25x100_v1_mc' ,SiPixelTemplatesRecord,connectionString, "", "2024-??-?? ??:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V, 3D pixels in TBPX L1
+    'T36' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v7.4.1_25x100_v2_mc' ,SiPixelTemplatesRecord,connectionStringDev, "", "2024-03-21 12:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V, 3D pixels in TBPX L1
 }
 
 allTags["TkAlignment"] = {
@@ -76,7 +77,7 @@ allTags["TkAlignment"] = {
     'T25' : ( ','.join( [ 'TrackerAlignment_Upgrade2026_T25_design_v0' ,TkAlRecord, connectionString, "", "2023-03-16 15:30:00"] ), ),
     'T30' : ( ','.join( [ 'TrackerAlignment_Upgrade2026_T30_design_v0' ,TkAlRecord, connectionString, "", "2023-03-16 15:30:00"] ), ),
     'T33' : ( ','.join( [ 'TrackerAlignment_Upgrade2026_T33_design_v0' ,TkAlRecord, connectionString, "", "2023-06-07 21:00:00"] ), ),
-  #  'T36' : ( ','.join( [ 'TrackerAlignment_Upgrade2026_T36_design_v0' ,TkAlRecord, connectionString, "", "2024-??-?? ??:00:00"] ), ),
+    'T36' : ( ','.join( [ 'TrackerAlignment_Upgrade2026_T36_design_v2' ,TkAlRecord, connectionStringDev, "", "2024-03-21 13:10:00"] ), ),
 }
 
 allTags["TkAPE"] = {
@@ -84,7 +85,7 @@ allTags["TkAPE"] = {
     'T25' : ( ','.join( [ 'TrackerAlignmentErrorsExtended_Upgrade2026_T25_design_v0' ,TkAPERecord, connectionString, "", "2023-03-16 15:30:00"] ), ),
     'T30' : ( ','.join( [ 'TrackerAlignmentErrorsExtended_Upgrade2026_T30_design_v0' ,TkAPERecord, connectionString, "", "2023-03-16 15:30:00"] ), ),
     'T33' : ( ','.join( [ 'TrackerAlignmentErrorsExtended_Upgrade2026_T33_design_v0' ,TkAPERecord, connectionString, "", "2023-06-07 21:00:00"] ), ),
-#    'T36' : ( ','.join( [ 'TrackerAlignmentErrorsExtended_Upgrade2026_T36_design_v0' ,TkAPERecord, connectionString, "", "2024-??-?? ??:00:00"] ), ),
+    'T36' : ( ','.join( [ 'TrackerAlignmentErrorsExtended_Upgrade2026_T36_design_v2' ,TkAPERecord, connectionStringDev, "", "2024-03-21 13:10:00"] ), ),
 }
 
 allTags["TkSurf"] = {
@@ -92,7 +93,7 @@ allTags["TkSurf"] = {
     'T25' : ( ','.join( [ 'TrackerSurfaceDeformations_Upgrade2026_Zero' ,TkSurfRecord, connectionString, "", "2023-03-16 15:30:00"] ), ),
     'T30' : ( ','.join( [ 'TrackerSurfaceDeformations_Upgrade2026_Zero' ,TkSurfRecord, connectionString, "", "2023-03-16 15:30:00"] ), ),
     'T33' : ( ','.join( [ 'TrackerSurfaceDeformations_Upgrade2026_Zero' ,TkSurfRecord, connectionString, "", "2023-03-16 15:30:00"] ), ),
- #   'T36' : ( ','.join( [ 'TrackerSurfaceDeformations_Upgrade2026_Zero' ,TkSurfRecord, connectionString, "", "2024-??-?? ??:00:00"] ), ),
+    'T36' : ( ','.join( [ 'TrackerSurfaceDeformations_Upgrade2026_Zero' ,TkSurfRecord, connectionString, "", "2023-03-16 15:00:00"] ), ),
 }
 
 ##
@@ -131,7 +132,7 @@ allTags["Template2Dden"] = {
 activeKeys = ["LA", "LAWidth", "SimLA", "LAfromAlignment", "GenError", "Template", "TkAlignment", "TkAPE", "TkSurf"] #,"SimOTLA","OTLA"]
 
 # list of geometries supported
-activeDets = ["T21","T25","T30","T33"]#,"T36"]
+activeDets = ["T21","T25","T30","T33","T36"]
 phase2GTs = {}
 for det in activeDets:
     appendedTags = ()

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -3056,7 +3056,7 @@ upgradeProperties[2026] = {
     '2026D110' : {
         'Geom' : 'Extended2026D110',
         'HLTmenu': '@relval2026',
-        'GT' : 'auto:phase2_realistic_T33',
+        'GT' : 'auto:phase2_realistic_T36',
         'Era' : 'Phase2C22I13M9',
         'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal', 'ALCAPhase2'],
     },


### PR DESCRIPTION
#### PR description:

Title says it all.

#### PR validation:

Run with this PR on top of the branch:

```
runTheMatrix.py -l 29634.0 -t 4 -j 8 --ibeos
```

if one applies:

```diff
diff --git a/L1Trigger/TrackFindingTracklet/src/MatchCalculator.cc b/L1Trigger/TrackFindingTracklet/src/MatchCalculator.cc
index b39cc0d31e3..f37e60aa42d 100644
--- a/L1Trigger/TrackFindingTracklet/src/MatchCalculator.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchCalculator.cc
@@ -200,7 +200,7 @@ void MatchCalculator::execute(unsigned int iSector, double phioffset) {
 
       if (settings_.useapprox()) {
         double dphi = reco::reduceRange(phi - fpgastub->phiapprox(0.0, 0.0));
-        assert(std::abs(dphi) < 0.001);
+        assert(std::abs(dphi) < 0.1);
         phi = fpgastub->phiapprox(0.0, 0.0);
         z = fpgastub->zapprox();
         r = fpgastub->rapprox();
```

it runs without any warning or errors.
Otherwise it has the "usual" assertion failure:

```
cmsRun: src/L1Trigger/TrackFindingTracklet/src/MatchCalculator.cc:203: void trklet::MatchCalculator::execute(unsigned int, double): Assertion `std::abs(dphi) < 0.001' failed.
```