### PR TITLE
update alignment payload for tracker geometry T36

### DIFF
--- a/Configuration/AlCa/python/autoCondPhase2.py
+++ b/Configuration/AlCa/python/autoCondPhase2.py
@@ -77,7 +77,7 @@ allTags["TkAlignment"] = {
     'T25' : ( ','.join( [ 'TrackerAlignment_Upgrade2026_T25_design_v0' ,TkAlRecord, connectionString, "", "2023-03-16 15:30:00"] ), ),
     'T30' : ( ','.join( [ 'TrackerAlignment_Upgrade2026_T30_design_v0' ,TkAlRecord, connectionString, "", "2023-03-16 15:30:00"] ), ),
     'T33' : ( ','.join( [ 'TrackerAlignment_Upgrade2026_T33_design_v0' ,TkAlRecord, connectionString, "", "2023-06-07 21:00:00"] ), ),
-    'T36' : ( ','.join( [ 'TrackerAlignment_Upgrade2026_T36_design_v2' ,TkAlRecord, connectionStringDev, "", "2024-03-21 13:10:00"] ), ),
+    'T36' : ( ','.join( [ 'TrackerAlignment_Upgrade2026_T36_design_v3' ,TkAlRecord, connectionStringDev, "", "2024-03-28 15:19:00"] ), ),
 }
 
 allTags["TkAPE"] = {


### PR DESCRIPTION
#### PR description:

Title says it all, to capture the latest updates in the geometry description.

#### PR validation:

With this on top of the branch ` runTheMatrix.py -l 29634.0 -t 4 -j 8 --ibeos` runs without issues.
For reference here is the comparison between `TrackerAlignment_Upgrade2026_T36_design_v3` and `TrackerAlignment_Upgrade2026_T36_design_v2`

![image](https://github.com/Raffaella07/cmssw/assets/5082376/f5c81ff4-0d1f-48dc-b02c-efab42d287b4)

____

here a OT-only comparison of T36 (v3) and T30:

![image](https://github.com/Raffaella07/cmssw/assets/5082376/a5d27cc1-2dac-4c4b-93f7-f20649d40ee3)

____

and here the same thing, but in cylindrical coordinates:

![image](https://github.com/Raffaella07/cmssw/assets/5082376/5ba12ecd-f806-4b04-a662-15516156bff2)
